### PR TITLE
正解/不正解画面をつくったよ〜

### DIFF
--- a/src/Correct.tsx
+++ b/src/Correct.tsx
@@ -1,0 +1,44 @@
+import { StatusBar } from "expo-status-bar";
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+export default function Correct() {
+	return (
+		<View style={styles.container}>
+			<Text style={styles.correctText}>
+				正解！
+			</Text>
+			<View style={styles.buttonContainer}>
+				<Text
+					style={styles.baseText}
+					onPress={() => console.log("cannot get back to top yet :(")}
+				>
+					TOPへ戻る
+				</Text>
+			</View>
+			<StatusBar style="auto" />
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		backgroundColor: "#fff",
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	buttonContainer: {
+		position: "absolute",
+		bottom: 100,
+	},
+	correctText: {
+		fontSize: 100,
+		fontWeight: "bold",
+		color: "#dc143c",
+	},
+	baseText: {
+		fontSize: 20,
+		color: "#ccc",
+	},
+});

--- a/src/Incorrect.tsx
+++ b/src/Incorrect.tsx
@@ -1,0 +1,44 @@
+import { StatusBar } from "expo-status-bar";
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+export default function Inorrect() {
+	return (
+		<View style={styles.container}>
+			<Text style={styles.incorrectText}>
+				残念(TT)
+			</Text>
+			<View style={styles.buttonContainer}>
+				<Text
+					style={styles.baseText}
+					onPress={() => console.log("cannot get back to top yet :(")}
+				>
+					TOPへ戻る
+				</Text>
+			</View>
+			<StatusBar style="auto" />
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		backgroundColor: "#fff",
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	buttonContainer: {
+		position: "absolute",
+		bottom: 100,
+	},
+	incorrectText: {
+		fontSize: 100,
+		fontWeight: "bold",
+		color: "#274a78",
+	},
+	baseText: {
+		fontSize: 20,
+		color: "#ccc",
+	},
+});


### PR DESCRIPTION
Closes #9 

## 概要
- Correct.tsx, Incorrect.tsx を追加した

## どのような変更か
- App をほぼコピペして Correct.tsx, Incorrect.tsx を追加した
- 文言を変えてちょっとスタイルもつけた
  - 色は原色を避けた。目が痛くなるので
- 「TOPに戻る」の文言を画面下の方に出るようにした

## 確認して欲しい観点
- コーディングのお作法

## テストしたこと・確認したこと
- index.tsx に以下の差分をつくった上で
  ```
  +import Correct from "./src/Correct";
 
   export default function Main() {
  -	return <App />;
  +	return <Correct />;
   }
  ```
- 実機で画面確認＆「TOPに戻る」のタップ確認
  - incorrect も同様にした
  - タップしたらターミナルに `not yet :(` 的なのが出て感動した
  - <kbd><img src="https://user-images.githubusercontent.com/90500950/136701450-66f4a091-8c8e-4b19-9798-f306bb63e5f4.jpg" width="250px" border="1"></kbd> <kbd><img src="https://user-images.githubusercontent.com/90500950/136701455-f776704c-b6c3-4ace-b7a6-1ae7d7f77b1c.jpg" width="250px" border="1"></kbd>



## やらないこと
- ボタンや遷移はまだ導入しません
- デザインは react-native お試しレベルでしかいじらないのでFIXではありません

## その他
- これは tips ですが
  - スクショの画像が大きすぎるときには img タグで貼って width=NNN のように指定すれば良いらしい
  - 背景色が白で境界がわからない場合は \<kbd\>\<img ~\>\</kbd\> とすると↑のようになる
