### PR TITLE
問題画面を追加

### DIFF
--- a/src/constants/question.ts
+++ b/src/constants/question.ts
@@ -1,0 +1,21 @@
+export const questionInfo = {
+	bodyText: "HR図のHRとは何の略？",
+	choiceList: [
+		{
+			text: "ホームルーム",
+			answer: false,
+		},
+		{
+			text: "ヘルツシュプルング・ラッセル",
+			answer: true,
+		},
+		{
+			text: "ヒューマンリソース",
+			answer: false,
+		},
+		{
+			text: "ハートレート",
+			answer: false,
+		},
+	],
+};

--- a/src/screens/Question.tsx
+++ b/src/screens/Question.tsx
@@ -1,0 +1,58 @@
+import { StatusBar } from "expo-status-bar";
+import React from "react";
+import { Button } from "react-native-paper";
+import { StyleSheet, Text, View } from "react-native";
+import { questionInfo } from "../constants/question";
+
+export default function Question() {
+	return (
+		<View style={styles.container}>
+			<StatusBar style="auto" />
+			<Text style={styles.headerText}>Q1</Text>
+			<Text style={styles.baseText}>{questionInfo.bodyText}</Text>
+			{questionInfo.choiceList.map((item, idx) => {
+				return (
+					<Button
+						mode="contained"
+						onPress={() => console.log("Pressed")}
+						style={styles.button}
+						/* https://reactnative.dev/docs/text-style-props */
+						labelStyle={styles.buttonLabel}
+						key={idx}
+					>
+						{item.text}
+					</Button>
+				);
+			})}
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		backgroundColor: "#fff",
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	headerText: {
+		fontSize: 100,
+		fontWeight: "bold",
+		color: "#274a78",
+	},
+	baseText: {
+		fontSize: 20,
+		color: "#274a78",
+		marginBottom: 30,
+	},
+	button: {
+		width: "80%",
+		marginTop: 10,
+		marginBottom: 10,
+	},
+	buttonLabel: {
+		fontSize: 15,
+		height: 30,
+		textAlignVertical: "center",
+	},
+});


### PR DESCRIPTION
Closes #8 

## 概要
- 久々〜のpush
- 画面を一通り用意するために問題画面を作った

## どのような変更か
- 問題画面用のコンポーネントを追加
- 問題と選択肢は切り出して定義

## 確認して欲しい観点
- さらっと
<img src="https://user-images.githubusercontent.com/15265318/145682767-d05f8158-4c83-4752-8301-2e4b9b7a65f0.png" width=300></img>

## テストしたこと・確認したこと
- topの呼び出しコンポーネントをQuestion.tsxにして画面確認

## やらないこと
- 導線の遷移とかとか
- 配置は適当です 😇 
