### PR TITLE
TypeScript is updated to 4.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8542,9 +8542,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
-      "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+      "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "prettier": "^2.4.0",
-    "typescript": "~4.0.0"
+    "typescript": "4.5.3"
   },
   "private": true
 }


### PR DESCRIPTION
Closes #18 

## 概要
- React Navigationを使うためにTSのupdate

## テストしたこと・確認したこと
- 画面が無事に開けること
