### PR TITLE
正誤画面のデザイン修正

### DIFF
--- a/src/screens/Correct.tsx
+++ b/src/screens/Correct.tsx
@@ -41,6 +41,7 @@ const styles = StyleSheet.create({
 		fontSize: 100,
 		fontWeight: "bold",
 		color: "#dc143c",
+		textAlign: "center",
 	},
 	baseText: {
 		fontSize: 20,

--- a/src/screens/Incorrect.tsx
+++ b/src/screens/Incorrect.tsx
@@ -41,6 +41,7 @@ const styles = StyleSheet.create({
 		fontSize: 100,
 		fontWeight: "bold",
 		color: "#274a78",
+		textAlign: "center",
 	},
 	baseText: {
 		fontSize: 20,


### PR DESCRIPTION
Closes #23

## 概要
- 正誤画面(特に誤答)のテキストが左寄りになっていたので、デザインを当てて中心に来るように修正

## どのような変更か
- textAlign:center を突っ込んだ

## 確認して欲しい観点
- なし

## テストしたこと・確認したこと
- pixel4で中央に表示されること